### PR TITLE
fix: dynamic_retrieval_config option for WebSearch agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ This Changelog format is based on [Keep a Changelog]
 adheres to [Semantic Versioning](https://semver.org/spec/
 v2.0.0.html).
 
-## [3.3.0] - 2024-12-11
+## [3.3.1] - 2024-12-11
+
+### Changed
+- Fixed Websearch agent configuration in `agentConfig.json`
+- Refactored agent configuration structure in `src/agents/agentConfig.ts` for better type safety and maintainability
+
+## [3.3.0] - 2024-12-10
 
 ### Added
 - Added `getUsageCost` method to track API usage costs and token metrics

--- a/agentConfig.json
+++ b/agentConfig.json
@@ -62,7 +62,11 @@
       },
       "options": {
         "debug": true,
-        "googleSearchRetrieval": true
+        "googleSearchRetrieval": {
+          "dynamic_retrieval_config": {
+            "mode": "MODE_UNSPECIFIED"
+          }
+        }
       },
       "functions": ["CurrentDateTime", "DaysBetweenDates"]
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@amitdeshmukh/ax-crew",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Build and launch a crew of AI agents with shared state. Built with axllm.dev",
   "main": "dist/index.js",
   "engines": {

--- a/src/agents/agentConfig.ts
+++ b/src/agents/agentConfig.ts
@@ -173,21 +173,19 @@ const getAgentConfigParams = (
       throw new Error(`Provider key name is missing in the agent configuration`);
     }
 
-    // Create an instance of the AI agent
+    // Create an instance of the AI agent and set options
     const ai = new AIConstructor({
       apiKey,
       config: agentConfigData.ai,
       options: {
-        debug: agentConfigData.debug || false
+        debug: agentConfigData.debug || false,
+        ...agentConfigData.options
       }
     });
     // If an apiURL is provided in the agent config, set it in the AI agent
     if (agentConfigData.apiURL) {
       ai.setAPIURL(agentConfigData.apiURL);
     }
-
-    // Set all options from the agent configuration
-    ai.setOptions({ ...agentConfigData.options });
     
     // Prepare functions for the AI agent
     const agentFunctions = (agentConfigData.functions || [])


### PR DESCRIPTION
- Grounding with Google Search works now in the `WebSearch` agent 
- See `agentConfig.json`