### PR TITLE
feat: update MCP transport implementation to support current ax-llm framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ This Changelog format is based on [Keep a Changelog]
 adheres to [Semantic Versioning](https://semver.org/spec/
 v2.0.0.html).
 
+## [3.11.1] - 2025-06-04
+
+### Changed
+- Updated MCP (Model Context Protocol) transport implementation to support current ax-llm/ax framework
+- Replaced deprecated `AxMCPHTTPTransport` with `AxMCPHTTPSSETransport` for HTTP SSE transport
+- Added support for `AxMCPStreambleHTTPTransport` for streamable HTTP communication
+- Enhanced MCP configuration with proper TypeScript types using `AxMCPStreamableHTTPTransportOptions`
+- Updated transport configuration to use `mcpEndpoint` parameter for streamable HTTP transport
+
+### Removed
+- Removed all references to deprecated `MCPHTTPTransportConfig` interface
+- Cleaned up deprecated MCP transport type definitions
+
+### Added
+- Comprehensive MCP documentation in README.md with examples for all transport types
+- Added examples for STDIO, HTTP SSE, and streamable HTTP transport configurations
+- Enhanced MCP server configuration examples including filesystem, search, and database servers
+- Added migration guide for users upgrading from deprecated transport types
+
+### Fixed
+- Improved type safety for MCP transport configurations
+- Enhanced error handling for unsupported MCP transport types
+
 ## [3.10.0] - 2025-05-28
 
 ### Added

--- a/agentConfig.json
+++ b/agentConfig.json
@@ -108,6 +108,33 @@
           "solution": "Let's solve this step by step:\n1. The cube root of a number is a value that, when multiplied by itself twice, gives the original number\n2. For 27, we need to find a number that when cubed equals 27\n3. 3 × 3 × 3 = 27\nTherefore, the cube root of 27 is 3"
         }
       ]
+    },
+    {
+      "name": "DataAnalyst",
+      "description": "Analyzes data using MCP tools for file access and web search",
+      "signature": "analysisRequest:string \"a request to analyze data from files or web sources\" -> analysis:string \"detailed analysis with insights\"",
+      "provider": "openai",
+      "providerKeyName": "OPENAI_API_KEY",
+      "ai": {
+        "model": "gpt-4o-mini",
+        "temperature": 0
+      },
+      "options": {
+        "debug": true
+      },
+      "mcpServers": {
+        "filesystem": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        },
+        "brave-search": {
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+          "env": {
+            "BRAVE_API_KEY": "sk-1234567890"
+          }
+        }
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@amitdeshmukh/ax-crew",
-  "version": "3.8.1",
+  "version": "3.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@amitdeshmukh/ax-crew",
-      "version": "3.8.1",
+      "version": "3.11.1",
       "license": "MIT",
       "dependencies": {
+        "@ax-llm/ax": "^11.0.50",
         "decimal.js": "^10.5.0",
         "dotenv": "^16.4.5",
         "upgrade": "^1.1.0",
@@ -25,9 +26,6 @@
       },
       "engines": {
         "node": ">=21.0.0"
-      },
-      "peerDependencies": {
-        "@ax-llm/ax": "^11.0.47"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -52,11 +50,10 @@
       }
     },
     "node_modules/@ax-llm/ax": {
-      "version": "11.0.47",
-      "resolved": "https://registry.npmjs.org/@ax-llm/ax/-/ax-11.0.47.tgz",
-      "integrity": "sha512-SinhxfzEUxjhUimLILGjPFQwKw2ytJBknzkUmiJbbMNqQjLpbjJV4eP5/lvSk78too/ijm1m+EobSRWaDwmIUg==",
+      "version": "11.0.50",
+      "resolved": "https://registry.npmjs.org/@ax-llm/ax/-/ax-11.0.50.tgz",
+      "integrity": "sha512-TJGz47C25eRKEpeBwbfEb4mXquTIL1JXuMWelMvRXpqz27fb66QBq10DrWGpBhki1qcCvp5XyPXATrNAkE30iw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "google-auth-library": "^9.15.1",
@@ -634,7 +631,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1155,7 +1151,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -1234,15 +1229,13 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -1261,8 +1254,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1421,7 +1413,6 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -1505,8 +1496,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.4.3",
@@ -1574,7 +1564,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -1595,7 +1584,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1605,7 +1593,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -1641,7 +1628,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -1659,7 +1645,6 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1669,7 +1654,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -1700,7 +1684,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -1734,7 +1717,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -1824,19 +1806,17 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
@@ -1846,7 +1826,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -1952,17 +1931,15 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.47",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.47.tgz",
-      "integrity": "sha512-UbNt/JAWS0m/NJOebR0QMRHBk0hu03r5dx9GK8Cs0AS3I81yDcOc9k+DytPItgVvBP7J6Mf6U2n3BPAacAV9oA==",
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -2010,7 +1987,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2205,8 +2181,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -2523,8 +2498,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.7.3",
@@ -2735,15 +2709,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@amitdeshmukh/ax-crew",
-  "version": "3.10.0",
+  "version": "3.11.1",
   "description": "Build and launch a crew of AI agents with shared state. Built with axllm.dev",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,13 +17,11 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@ax-llm/ax": "^11.0.50",
     "decimal.js": "^10.5.0",
     "dotenv": "^16.4.5",
     "upgrade": "^1.1.0",
     "uuid": "^10.0.0"
-  },
-  "peerDependencies": {
-    "@ax-llm/ax": "^11.0.47"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import type { 
   AxFunction, 
   AxSignature, 
-  AxModelConfig 
+  AxModelConfig,
+  AxMCPStreamableHTTPTransportOptions
 } from '@ax-llm/ax';
 
 import type { Provider } from './agents/agentConfig.js';
@@ -115,15 +116,32 @@ interface MCPStdioTransportConfig {
   env?: NodeJS.ProcessEnv
 }
 
-interface MCPHTTPTransportConfig {
+/**
+ * Config for an HTTP SSE MCP server.
+ * 
+ * @property {string} sseUrl - The SSE URL for the MCP server.
+ */
+interface MCPHTTPSSETransportConfig {
   sseUrl: string
 }
+
+/**
+ * Config for a streamable HTTP MCP server.
+ * 
+ * @property {string} mcpEndpoint - The HTTP endpoint URL for the MCP server.
+ * @property {AxMCPStreamableHTTPTransportOptions} options - Optional transport options.
+ */
+interface MCPStreambleHTTPTransportConfig {
+  mcpEndpoint: string
+  options?: AxMCPStreamableHTTPTransportOptions
+}
+
 /**
  * Config for an MCP server.
  * 
- * @property {MCPStdioTransportConfig | MCPHTTPTransportConfig} config - The config for the MCP server. Config can be either a stdio or http transport.
+ * @property {MCPStdioTransportConfig | MCPHTTPSSETransportConfig | MCPStreambleHTTPTransportConfig} config - The config for the MCP server. Config can be either stdio, http-sse, or streamable http transport.
  */
-type MCPTransportConfig = MCPStdioTransportConfig | MCPHTTPTransportConfig
+type MCPTransportConfig = MCPStdioTransportConfig | MCPHTTPSSETransportConfig | MCPStreambleHTTPTransportConfig
 
 /**
  * The configuration for an agent.
@@ -170,7 +188,8 @@ export {
   type StateInstance,
   type FunctionRegistryType,
   type MCPStdioTransportConfig,
-  type MCPHTTPTransportConfig,
+  type MCPHTTPSSETransportConfig,
+  type MCPStreambleHTTPTransportConfig,
   type MCPTransportConfig,
   type ModelUsage,
   type ModelInfo,


### PR DESCRIPTION
- Replace deprecated AxMCPHTTPTransport with AxMCPHTTPSSETransport 
- Add support for AxMCPStreambleHTTPTransport with proper options handling 
- Remove deprecated MCPHTTPTransportConfig interface and references 
- Add comprehensive MCP documentation with examples for all transport types 
- Update type definitions to use AxMCPStreamableHTTPTransportOptions 
- Add example agent configuration with MCP servers - Update changelog for v3.11.1