### PR TITLE
Feat/persona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+## [4.1.0] - 2025-08-25
+
+### Added
+- Agent persona support via `definition` with validation (>= 100 chars).
+- `prompt` alias for persona; `definition` takes precedence when both provided.
+
+### Changed
+- README updated to document `definition`/`prompt` usage with example.
+- Example `examples/mcp-agent.ts` demonstrates `prompt` in agent config.
+
 ## [4.0.1] - 2025-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,6 +174,25 @@ Both methods support the same configuration structure and options. Choose the on
   - Modify configurations at runtime
   - Keep everything in one file for simpler projects
 
+### Agent Persona: definition and prompt
+
+- **definition**: Detailed persona/program description used as the system prompt. Recommended for precise control. Must be at least 100 characters.
+- **prompt**: An alias for definition for human clarity. If both are provided, **definition** takes precedence.
+
+Add either field to any agent config. The chosen value becomes the Ax agent's underlying program description (system prompt).
+
+```json
+{
+  "name": "Planner",
+  "description": "Creates a plan to complete a task",
+  "prompt": "You are a meticulous planning assistant. Produce concise, executable step-by-step plans with clear justifications, constraints, and assumptions. Prefer brevity, avoid fluff, and ask for missing critical details before proceeding when necessary.",
+  "signature": "task:string -> plan:string",
+  "provider": "google-gemini",
+  "providerKeyName": "GEMINI_API_KEY",
+  "ai": { "model": "gemini-1.5-flash", "temperature": 0 }
+}
+```
+
 ### Agent Examples
 You can provide examples to guide the behavior of your agents using the `examples` field in the agent configuration. Examples help the agent understand the expected input/output format and improve its responses.
 

--- a/examples/mcp-agent.ts
+++ b/examples/mcp-agent.ts
@@ -1,15 +1,15 @@
-import { AxCrew } from "../dist/index.js";
-import type { AxCrewConfig } from "../dist/index.js";
+import { AxCrew, AxCrewConfig } from "../dist/index.js";
 
 import dotenv from "dotenv";
 dotenv.config();
 
 // Define the crew configuration
-const config: AxCrewConfig = {
+const config = {
   crew: [
     {
       name: "MapsAgent",
       description: "A specialized agent with access to Google Maps APIs that can: geocode addresses to coordinates and vice versa, search for and get details about places, calculate travel distances and times between multiple locations, provide elevation data, and generate navigation directions between points.",
+      prompt: "You are a precise geospatial assistant with expert knowledge of Google Maps APIs. Answer user queries by combining place search, geocoding, distance matrix, elevation, and directions. Provide concise, actionable answers, include travel mode assumptions, and cite uncertainties. When location is ambiguous, ask a brief clarifying question before proceeding.",
       signature: 'userQuery:string "a question to be answered" -> answer:string "the answer to the question"',
       provider: "anthropic",
       providerKeyName: "ANTHROPIC_API_KEY",
@@ -38,6 +38,7 @@ const config: AxCrewConfig = {
     {
       name: "ManagerAgent",
       description: "Completes a user specified task",
+      prompt: "You are a manager agent that orchestrates tools and sub-agents. Read the user's objective, optionally produce a short plan, then call the MapsAgent when geospatial knowledge is needed. Keep answers direct and avoid extraneous commentary.",
       signature:
         'question:string "a question to be answered" -> answer:string "the answer to the question"',
       provider: "openai", 
@@ -73,7 +74,7 @@ const config: AxCrewConfig = {
 };
 
 // Create a new instance of AxCrew with the config
-const crew = new AxCrew(config);
+const crew = new AxCrew(config as AxCrewConfig);
 
 // Add the agents to the crew
 await crew.addAllAgents();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@amitdeshmukh/ax-crew",
-  "version": "4.0.1",
+  "version": "4.1.1",
   "description": "Build and launch a crew of AI agents with shared state. Built with axllm.dev",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/agents/agentConfig.ts
+++ b/src/agents/agentConfig.ts
@@ -224,7 +224,7 @@ const parseAgentConfig = async (
     }
 
     // Create a cost tracker instance and pass to ai()
-    const costTracker = new AxDefaultCostTracker();
+    const costTracker = new AxDefaultCostTracker(((agentConfigData as any).options?.costTracking) || undefined);
 
     // Create an instance of the AI agent via factory
     const aiArgs: any = {
@@ -273,6 +273,7 @@ const parseAgentConfig = async (
       ai: aiInstance,
       name: agentName,
       description: agentConfigData.description,
+      definition: (agentConfigData as any).definition ?? (agentConfigData as any).prompt,
       signature: agentConfigData.signature,
       functions: agentFunctions,
       subAgentNames: agentConfigData.agents || [],

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -27,6 +27,7 @@ interface ParsedAgentConfig {
   ai: AxAI;
   name: string;
   description: string;
+  definition?: string;
   signature: string | AxSignature;
   functions: (
     | AxFunction
@@ -58,6 +59,7 @@ class StatefulAxAgent extends AxAgent<any, any> {
     options: Readonly<{
       name: string;
       description: string;
+      definition?: string;
       signature: string | AxSignature;
       agents?: AxAgentic<any, any>[] | undefined;
       functions?: (AxFunction | (() => AxFunction))[] | undefined;
@@ -347,6 +349,7 @@ class AxCrew {
         {
           name,
           description,
+          definition: (agentConfig as any).definition,
           signature,
           functions: uniqueFunctions,
           agents: uniqueSubAgents,

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,16 @@ type MCPTransportConfig = MCPStdioTransportConfig | MCPHTTPSSETransportConfig | 
 interface AgentConfig {
   name: string;
   description: string;
+  /**
+   * Optional detailed persona/program definition. If provided, becomes the system prompt.
+   * Must be at least 100 characters per Ax semantics.
+   */
+  definition?: string;
+  /**
+   * Optional alias for definition for clarity. If provided and definition is omitted,
+   * this will be used as the program definition/system prompt.
+   */
+  prompt?: string;
   signature: string | AxSignature;
   provider: Provider;
   providerKeyName?: string;


### PR DESCRIPTION
- Add support for the `definition` field from `@ax-llm/ax` framework to provide a detailed system prompt to the agents LLM
- Also support `prompt` which is an alias for `definition` 
- update `README.md`